### PR TITLE
Pull: File System Authentication

### DIFF
--- a/src/Chord.js
+++ b/src/Chord.js
@@ -31,6 +31,11 @@ class ConductorChord {
 				cacheAnswerDuration: 20000
 			},
 
+			fileStore: {
+				itemDuration: 30000,
+				itemRefreshPeriod: 5000
+			},
+
 			messageMaxHops: 448,
 
 			serverConfig: {
@@ -453,6 +458,10 @@ class ConductorChord {
 
 	lookupItem(key){
 		return this.fileStore.retrieve(key);
+	}
+
+	updateItem (key, value) {
+		return this.fileStore.update(key, value);
 	}
 
 	message(msg){

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -237,7 +237,7 @@ class ConductorChord {
 				disconnected: { 
 					_onEnter() {
 						//force predecessor and all fingers to be self...
-						t.node.initOn();
+						t.node.clean();
 
 						if(t.config.isServer)
 							this.transition("full_server");

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -2,12 +2,24 @@
 
 const RemoteCallable = require("./RemoteCallable.js"),
 	ID = require("./ID.js"),
-	sha3 = require("js-sha3");
+	sha3 = require("js-sha3"),
+	pki = require("node-forge").pki,
+	random = require("node-forge").random,
+	cipher = require("node-forge").cipher,
+	forgeUtil = require("node-forge").util;
+
+const STORE_OKAY = 0,
+	FILE_EXISTS = 1,
+	BAD_UPDATE = 2,
+	UPDATE_OKAY = 4,
+	NO_FILE = 5,
+	KEEPALIVE_OKAY = 6;
 
 class FileStore extends RemoteCallable {
 	constructor (chord) {
 		super(chord, "ChordFS")
 		this.storage = {};
+		this.ownedObjects = {};
 
 		chord.registerModule(this);
 	}
@@ -18,7 +30,7 @@ class FileStore extends RemoteCallable {
 
 		switch (message.handler) {
 			case "store":
-				this.store(message.data.params[0], message.data.params[1])
+				this._authStore(message.data.params[0], message.data.params[1], message.data.params[2])
 					.then(
 						response => this.answer(message, response)
 					)
@@ -35,18 +47,59 @@ class FileStore extends RemoteCallable {
 						reason => this.error(message, reason)
 					);
 				break;
+			case "update":
+				this._rcvUpdate(message.data.params)
+					.then(
+						response => this.answer(message, response)
+					)
+					.catch(
+						reason => this.error(message, reason)
+					);
+				break;
+			case "keepAlive":
+				this._rcvKeepAlive(message.data.params[0])
+					.then(
+						response => this.answer(message, response)
+					)
+					.catch(
+						reason => this.error(message, reason)
+					);
+				break;
 			default:
 				break;
 		}
 	}
 
 	store (key, value) {
-		let internalObj = {
-				data: (typeof value === "string") ? value : JSON.stringify(value),
-				wasStr: typeof value === "string"
-			},
-			hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
-			hashStr = ID.coerceString(new ID(hash));
+		return this._authStore(key, value, this.chord.pubKeyPem)
+			.then(
+				result => {
+					switch (result.code) {
+						case STORE_OKAY:
+							//Try to decrypt the AES key.
+							let newKey;
+							try {
+								newKey = this.chord.key.privateKey.decrypt(result.encKey, "RSA-OAEP");
+							} catch (e) {
+								throw new Error("CFS: Couldn't decrypt ownership AES.");
+							}
+
+							//Store a reference to the owned object.
+							//Create a regular event to ping the item to keep it alive.
+							this.storeOwnershipKey(key, newKey, result.seq, result.lHash)
+
+							break;
+						case FILE_EXISTS:
+							break;
+					}
+				}
+			);
+	}
+
+	_authStore (key, value, pubKeyPem) {
+		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+			hashStr = ID.coerceString(new ID(hash)),
+			presentObj = this.storage[hashStr];
 
 		//If we are indeed the successor to this node, store it.
 		//Otherwise send this message abroad.
@@ -54,12 +107,135 @@ class FileStore extends RemoteCallable {
 		//Computation of the hash MUST be determined at the node responsible for storage,
 		//to prevent unbalanced/incorrect storage and related attacks.
 
+		//If an object exists here, rebuff the requester...
+
+		if(presentObj)
+			return Promise.resolve({code: FILE_EXISTS, kHash: hashStr, seq: presentObj.seq, lHash: presentObj.lHash});
+
+		let internalObj = {
+			data: (typeof value === "string") ? value : JSON.stringify(value),
+			wasStr: typeof value === "string",
+			lHash: ID.coerceString(new ID(sha3["sha3_"+this.chord.config.idWidth].buffer(value))),
+			aesKey: random.getBytesSync(16),
+			seq: 0
+		},
+			//Prepare the ownership aes key so that only the sender can access the item.
+			cryptor = pki.publicKeyFromPem(pubKeyPem),
+			securedKey = cryptor.encrypt(internalObj.aesKey, "RSA-OAEP");
+			
 		if(!this.chord.node.predecessor || ID.inLeftOpenBound(hash, this.chord.node.predecessor.id, this.chord.node.id)){
+			//Store the item
 			this.storage[hashStr] = internalObj;
-			return Promise.resolve(true);
+
+			//Set a timeout so that the object will be killed if no user desires that it stays alive.
+			internalObj.timeout = setTimeout(()=>{
+				delete this.storage[hashStr];
+			}, this.chord.config.fileStore.itemDuration);
+
+			return Promise.resolve({code: STORE_OKAY, kHash: hashStr, seq: internalObj.seq, lHash: internalObj.lHash, encKey: securedKey});
 		} else {
-			return this.call(hash, "store", [key, value]);
+			return this.call(hashStr, "store", [key, value, this.chord.pubKeyPem]);
 		}	
+	}
+
+	update (key, value) {
+		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+			hashStr = ID.coerceString(new ID(hash)),
+			currentObj = this.ownedObjects[hashStr];
+
+		if(!currentObj)
+			return Promise.reject("CFS: Cannot update item - not owned.");
+
+		let encData = FileStore.encrypt(JSON.stringify({h:currentObj.lHash, s: currentObj.seq}), currentObj.aesKey)
+
+		return this.call(hashStr, "update", [key, value, encData.data, encData.iv, encData.tag])
+			.then(
+				result => {
+					//TODO
+					//update seq, lHash...
+					switch (result.code) {
+						case UPDATE_OKAY:
+							break;
+						case NO_FILE:
+							//Not a whole lot we can do here?
+							break;
+						case BAD_UPDATE:
+							//TODO: run another, identical call now that we have updated seq and
+							//lHash. If this fails, then I guess you never had rights?
+							break;
+					}
+				}
+			)
+	}
+
+	_rcvUpdate (params) {
+		let key = params[0],
+			value = params[1],
+			authStr = params[2],
+			iv = params[3],
+			tag = params[4],
+			hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+			hashStr = ID.coerceString(new ID(hash)),
+			presentObj = this.storage[hashStr];
+
+		if (!presentObj) {
+			return Promise.resolve({code: NO_FILE});
+		}
+
+		try {
+			let out = JSON.parse(FileStore.decrypt(authStr, presentObj.aesKey, iv, tag));
+			
+			if (!out)
+				throw new Error("Error decoding auth-string.");
+
+			//Now, check lHash and seq.
+			//If they match, update was a success.
+			if(out.s < presentObj.seq || out.h !== presentObj.lHash)
+				throw new Error("seq or lHash did not match expected value!");
+
+			//Okay, we have a match!
+			this.storage[hashStr] = {
+				data: (typeof value === "string") ? value : JSON.stringify(value),
+				wasStr: typeof value === "string",
+				lHash: ID.coerceString(new ID(sha3["sha3_"+this.chord.config.idWidth].buffer(value))),
+				aesKey: presentObj.aesKey,
+				seq: out.s+1
+			};
+
+			return Promise.resolve({code: UPDATE_OKAY, seq: this.storage[hashStr].seq, lHash: this.storage[hashStr].lHash});
+
+		} catch (e) {
+			return Promise.resolve({code: BAD_UPDATE, seq: presentObj.seq, lHash: presentObj.lHash});
+		}
+
+	}
+
+	keepAlive (key) {
+		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+			hashStr = ID.coerceString(new ID(hash));
+
+		return this.call(hashStr, "keepAlive", [key]);
+	}
+
+	_rcvKeepAlive (key) {
+		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+			hashStr = ID.coerceString(new ID(hash)),
+			presentObj = this.storage[hashStr];
+
+		if (presentObj) {
+			//Clear old timeout ASAP...
+			if (presentObj.timeout)
+				clearTimeout(presentObj.timeout);
+
+			//And set a new one!
+			presentObj.timeout = setTimeout(()=>{
+				delete this.storage[hashStr];
+			}, this.chord.config.fileStore.itemDuration);
+
+			return Promise.resolve({code: KEEPALIVE_OKAY});
+		} else {
+			return Promise.resolve({code: NO_FILE});
+		}
 	}
 
 	retrieve (key) {
@@ -77,6 +253,70 @@ class FileStore extends RemoteCallable {
 		} else {
 			return this.call(hashStr, "retrieve", [key]);
 		}
+	}
+
+	storeOwnershipKey (key, aesKey, optSeq, optlHash) {
+		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+			keyHash = ID.coerceString(new ID(hash)),
+			failureCount = 0;
+
+		this.ownedObjects[keyHash] = {
+			aesKey,
+			seq: optSeq ? optSeq : 0,
+			lHash: optlHash ? optlHash : "AA==",
+			interval: setInterval(() => {
+				this.keepAlive(key)
+				.then(
+					result => {
+						switch(result.code){
+							case KEEPALIVE_OKAY:
+								//Everything is fine?
+								failureCount = 0;
+								break;
+							case NO_FILE:
+								//File was not found?
+								failureCount++;
+								if (failureCount > 6) {
+									//TODO: DELETE OWNERSHIP
+								}
+								break;
+						}
+					}
+				);
+			}, this.chord.config.fileStore.itemRefreshPeriod)
+		};
+	}
+
+	static encrypt (data, aesKey) {
+		let iv = random.getBytesSync(12),
+			cipherObj = cipher.createCipher('AES-GCM', aesKey);
+
+		cipherObj.start({
+			iv,
+			additionalData: 'binary-encoded string',
+			tagLength: 128
+		});
+
+		cipherObj.update(forgeUtil.createBuffer(data));
+		cipherObj.finish();
+
+		return {iv, data: cipherObj.output.data, tag: cipherObj.mode.tag.data};
+	}
+
+	static decrypt (cipherText, aesKey, iv, tag) {
+		let decipher = cipher.createDecipher('AES-GCM', aesKey);
+
+		decipher.start({
+			iv,
+			additionalData: 'binary-encoded string',
+			tagLength: 128,
+			tag: tag
+		});
+
+		decipher.update(forgeUtil.createBuffer(cipherText));
+		let success = decipher.finish();
+
+		return (success) ? decipher.output.data : null;
 	}
 }
 

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -304,8 +304,9 @@ class FileStore extends RemoteCallable {
 			obj = this.ownedObjects[keyHash];
 
 		if (obj) {
-			if(obj.interval)
+			if(obj.interval) {
 				clearInterval(obj.interval);
+			}
 
 			delete this.ownedObjects[keyHash];
 		}

--- a/src/Node.js
+++ b/src/Node.js
@@ -6,7 +6,6 @@ const u = require("./UtilFunctions.js"),
 
 class Node{
 	constructor(chord){
-		//TODO
 		this.id = chord.id;
 		this.chord = chord;
 		this.finger = [];
@@ -16,10 +15,6 @@ class Node{
 		for(var i=0; i<chord.config.idWidth; i++)
 			this.finger[i] = new Finger(this, i);
 	}
-
-	//NOTE:
-	//These show the algorithms, but they do not account for RPC, promises, callbacks etc...
-	//Redo these as time goes on.
 
 	setFinger(index, node){
 		//Set the node, and then check further indices to see if this node is a better fit.
@@ -69,14 +64,12 @@ class Node{
 		};
 	}
 
-	//Promise updated
 	getSuccessor(){
 		return new Promise((resolve, reject) => {
 			resolve(this.finger[0].node)
 		}); 
 	}
 
-	//Promise updated
 	setSuccessor(val){
 		return new Promise((resolve, reject) => {
 			let end = () => {
@@ -93,20 +86,16 @@ class Node{
 						() => end()
 					)
 			}
-
-			//this.finger[0].node = val;
 			
 		});
 	}
 
-	//Promise updated
 	getPredecessor(){
 		return new Promise((resolve, reject) => {
 			resolve(this.predecessor)
 		}); 
 	}
 
-	//Promise updated
 	setPredecessor(val){
 		return new Promise((resolve, reject) => {
 			this.predecessor = val;
@@ -118,112 +107,7 @@ class Node{
 			resolve(val);
 		});
 	}
-
-	//Promise updated
-	initOn(knownNode){
-		this.chord.server.connect = true;
-		if(knownNode){
-			return this.initialiseFingerTable(knownNode)
-				.then( () => {
-					return this.updateOthers();
-				} )
-				.then( () => {
-					if(!this.chord.server.node || !this.chord.server.node.isConnected())
-						this.chord.server.connect = false;
-				} );
-			//move keys from successor to self as well.
-		} else {
-			for(var i=0; i<this.chord.config.idwidth; i++)
-				this.finger[i].node = this;
-			this.predecessor = this;
-			if(!this.chord.server.node || !this.chord.server.node.isConnected())
-				this.chord.server.connect = false;
-			return Promise.resolve();
-		}
-
-	}
-
-	//Promise updated
-	initialiseFingerTable(knownNode){
-		return knownNode.findSuccessor(this.finger[0].start)
-			.then(
-				succ => {return this.setSuccessor(succ);}
-			)
-			.then(
-				succ => {return succ.getPredecessor();}
-			)
-			.then(
-				pred => {return this.setPredecessor(pred);}
-			)
-			.then(
-				() => {
-					let proms = [];
-
-					for(var i=0; i<this.finger.length-1; i++) {
-						let p = (proms.length===0) ? Promise.resolve() : proms[proms.length-1],
-							f = ((i)=>{
-								return () => {
-									if(ID.inRightOpenBound(this.finger[i+1].start, this.id, this.finger[i].node.id)){
-										//this.finger[i+1].node = this.finger[i].node;
-										this.setFinger(i+1, this.finger[i].node)
-									} else {
-										console.log(`Using new unknown node.`)
-										proms.push(
-											knownNode.findSuccessor(this.finger[i+1].start)
-												.then(
-													succ => {
-														//this.finger[i+1].node = succ;
-														this.setFinger(i+1, succ);
-													}
-												)
-										)
-									}
-								};
-							})(i);
-						p.then(f);
-					}
-
-					return Promise.all(proms);
-				}
-			);
-	}
-
-	//Promise updated
-	updateOthers(){
-		//Inform other nodes about our existence.
-		let proms = [];
-
-		for (var i = 0; i < this.finger.length; i++) {
-			//find last node p whose ith finger might be n
-			(i=>{proms.push(
-				this.findPredecessor(this.id.subtract(ID.powerOfTwoBuffer(i)))
-					.then(
-						p => {return p.updateFingerTable(this, i)}
-					)
-				)
-			})(i);
-		}
-
-		return Promise.all(proms);
-	}
-
-	//Promise updated
-	updateFingerTable(foreignNode, index){
-		//Update the finger of some remote node
-		if(ID.inRightOpenBound(foreignNode.id, this.id, this.finger[index].node.id)){
-			//this.finger[index].node = foreignNode;
-			this.setFinger(index, foreignNode);
-			return this.getPredecessor()
-				.then(
-					res => {return res.updateFingerTable(foreignNode, index)}
-				)
-		} else {
-			return Promise.resolve();
-		}
-
-	}
 	
-	//Promise updated
 	closestPrecedingFinger(id){
 		return new Promise( resolve => {
 			for (var i = this.finger.length - 1; i >= 0; i--) {
@@ -235,30 +119,12 @@ class Node{
 			resolve(this);
 		} );
 	}
-
-	firstSucceedingFinger(id) {
-		//New selector for fingers and self.
-		//cPF is maybe not appropriate for message routing.
-		//No promise support as can only be called locally, and only depends on local state.
-
-		//For each finger, check if the ID given is in the range (this, finger[i]]
-		//If so, return that node.
-		//If none found, return furthest finger.
-
-		for (var i = 0; i < this.finger.length-1; i++)
-			if(ID.inLeftOpenBound(id, this.id, this.finger[i].node.id))
-				return this.finger[i].node;
-
-		return this.finger[this.finger.length-1].node;
-	}
 	
-	//Promise updated
 	findSuccessor(id){
 		return this.findPredecessor(id)
 			.then( nPrime => { return nPrime.getSuccessor() } )
 	}
 	
-	//Promise updated
 	findPredecessor(id){
 		return new Promise( (resolve, reject) => {
 			let nPrime = this;
@@ -289,7 +155,6 @@ class Node{
 	}
 
 	//Stabilization methods
-	//Promise updated
 	stableJoin(knownNode){
 		let succ;
 
@@ -315,7 +180,6 @@ class Node{
 
 	//periodically verify n's immediate successor
 	//and tell the successor about n.
-	//Promise updated
 	stabilize(){
 		let oSucc;
 
@@ -362,7 +226,6 @@ class Node{
 
 	}
 
-	//Promise updated
 	notify(nPrime){
 		u.log(this.chord, `NOTIFIED BY:`);
 		u.log(this.chord, ID.coerceString(nPrime.id));
@@ -373,7 +236,6 @@ class Node{
 		return Promise.resolve();
 	}
 
-	//Promise updated
 	fixFingers(){
 		let i = Math.floor(Math.random() * (this.finger.length-1) + 1);
 		//this.finger[i].node = this.findSuccessor(this.finger[i].start);

--- a/src/Node.js
+++ b/src/Node.js
@@ -16,6 +16,14 @@ class Node{
 			this.finger[i] = new Finger(this, i);
 	}
 
+	clean () {
+		this.predecessor = this;
+
+		//Wipe the finger table
+		for(var i=0; i<this.finger.length; i++)
+			this.finger[i].node = this;
+	}
+
 	setFinger(index, node){
 		//Set the node, and then check further indices to see if this node is a better fit.
 		//Improvement over std chord.

--- a/src/RemoteCallModule.js
+++ b/src/RemoteCallModule.js
@@ -24,34 +24,10 @@ class RemoteCallModule extends RemoteCallable {
 						reason => this.error(message, reason)
 					);
 				break;
-			case "setSuccessor":
-				this.chord.node.setSuccessor(this.chord.obtainRemoteNode(message.data.params[0]))
-					.then(
-						result => this.answer(message, null)
-					);
-				break;
 			case "getPredecessor":
 				this.chord.node.getPredecessor()
 					.then(
 						result => this.answer(message, (result) ? result.id.idString : result)
-					)
-					.catch(
-						reason => this.error(message, reason)
-					);
-				break;
-			case "setPredecessor":
-				this.chord.node.setPredecessor(this.chord.obtainRemoteNode(message.data.params[0]))
-					.then(
-						result => this.answer(message, null)
-					)
-					.catch(
-						reason => this.error(message, reason)
-					);
-				break;
-			case "updateFingerTable":
-				this.chord.node.updateFingerTable(this.chord.obtainRemoteNode(message.data.params[0]), message.data.params[1])
-					.then(
-						result => this.answer(message, null)
 					)
 					.catch(
 						reason => this.error(message, reason)

--- a/src/RemoteNode.js
+++ b/src/RemoteNode.js
@@ -23,16 +23,6 @@ class RemoteNode {
 		});
 	}
 
-	setSuccessor(s){
-		//Send them an ID, return the remotenode supplied.
-		return new Promise((resolve, reject) => {
-			this.chord.rcm.call(this.id, "setSuccessor", [ID.coerceString(s.id)])
-				.then(result => resolve(s),
-					reason => reject(reason)
-				);
-		});
-	}
-
 	getPredecessor(){
 		//Return an ID, then create a remotenode from that.
 		return new Promise((resolve, reject) => {
@@ -41,20 +31,6 @@ class RemoteNode {
 					reason => reject(reason)
 				);
 		});
-	}
-
-	setPredecessor(p){
-		//Send them an ID, return the remotenode supplied.
-		return new Promise((resolve, reject) => {
-			this.chord.rcm.call(this.id, "setPredecessor", [ID.coerceString(p.id)])
-				.then(result => resolve(p),
-					reason => reject(reason)
-				);
-		});
-	}
-
-	updateFingerTable(foreignNode, index){
-		return this.chord.rcm.call(this.id, "updateFingerTable", [ID.coerceString(foreignNode.id), index]);
 	}
 
 	findSuccessor(id){

--- a/test/Chord.js
+++ b/test/Chord.js
@@ -34,7 +34,7 @@ describe("Chord", () => {
 			return expect(
 				new Promise((resolve, reject) => {
 					setTimeout(()=> {
-						c.fileStore.update(c.id.idString, "Hi there!")
+						c.updateItem(c.id.idString, "Hi there!")
 						.then(
 							result => {return c.lookupItem(c.id.idString)}
 						)
@@ -45,6 +45,28 @@ describe("Chord", () => {
 					}, 500)
 				})
 			).to.eventually.equal("Hi there!");
+		});
+
+		it("should be able to update an owned key more than once", () => {
+			var c = new Chord();
+
+			return expect(
+				new Promise((resolve, reject) => {
+					setTimeout(()=> {
+						c.updateItem(c.id.idString, "Hi there!")
+						.then(
+							result => {return c.updateItem(c.id.idString, "Hi again!")}
+						)
+						.then(
+							result => {return c.lookupItem(c.id.idString)}
+						)
+						.then(
+							result => resolve(result),
+							reason => reject(reason)
+						)
+					}, 500)
+				})
+			).to.eventually.equal("Hi again!");
 		});
 	});	
 });

--- a/test/Chord.js
+++ b/test/Chord.js
@@ -9,19 +9,21 @@ chai.use(chaiAsPromised);
 describe("Chord", () => {
 	describe("Construction", function() {
 		this.timeout(0);
+		var tim, c1, c2, c;
+
 		it("should construct without error, given no additional config", () => {
 			expect(()=>{var k = new Chord();}).to.not.throw(Error);
 		});
 
 		it("should be that two constructed instances have differing pub/priv key pairs", () => {
-			var c1 = new Chord();
-			var c2 = new Chord();
+			c1 = new Chord();
+			c2 = new Chord();
 
 			expect(JSON.stringify(c1.key) !== JSON.stringify(c2.key)).to.be.true;
 		});
 
 		it("should hold the entry corresponding to its own public key", () => {
-			var c = new Chord();
+			c = new Chord();
 
 			return expect(
 				c.lookupItem(c.id.idString)
@@ -48,7 +50,7 @@ describe("Chord", () => {
 		});
 
 		it("should be able to update an owned key more than once", () => {
-			var c = new Chord();
+			c = new Chord();
 
 			return expect(
 				new Promise((resolve, reject) => {
@@ -67,6 +69,18 @@ describe("Chord", () => {
 					}, 500)
 				})
 			).to.eventually.equal("Hi again!");
+		});
+
+		afterEach(() => {
+			if(tim)
+				clearTimeout(tim);
+
+			if(c)
+				c.fileStore.dropOwnership(c.id.idString);
+			if(c1)
+				c1.fileStore.dropOwnership(c1.id.idString);
+			if(c2)
+				c2.fileStore.dropOwnership(c2.id.idString);
 		});
 	});	
 });

--- a/test/Chord.js
+++ b/test/Chord.js
@@ -27,5 +27,24 @@ describe("Chord", () => {
 				c.lookupItem(c.id.idString)
 			).to.eventually.equal(c.pubKeyPem);
 		});
+
+		it("should be able to update any keys it has placed within the network.", () => {
+			var c = new Chord();
+
+			return expect(
+				new Promise((resolve, reject) => {
+					setTimeout(()=> {
+						c.fileStore.update(c.id.idString, "Hi there!")
+						.then(
+							result => {return c.lookupItem(c.id.idString)}
+						)
+						.then(
+							result => resolve(result),
+							reason => reject(reason)
+						)
+					}, 500)
+				})
+			).to.eventually.equal("Hi there!");
+		});
 	});	
 });

--- a/test/Chord.js
+++ b/test/Chord.js
@@ -10,20 +10,26 @@ describe("Chord", () => {
 	describe("Construction", function() {
 		this.timeout(0);
 		var tim, c1, c2, c;
+		var config = {
+			fileStore: {
+				itemDuration: 1000,
+				itemRefreshPeriod: 100
+			}
+		}
 
 		it("should construct without error, given no additional config", () => {
-			expect(()=>{var k = new Chord();}).to.not.throw(Error);
+			expect(()=>{c = new Chord(config);}).to.not.throw(Error);
 		});
 
 		it("should be that two constructed instances have differing pub/priv key pairs", () => {
-			c1 = new Chord();
-			c2 = new Chord();
+			c1 = new Chord(config);
+			c2 = new Chord(config);
 
 			expect(JSON.stringify(c1.key) !== JSON.stringify(c2.key)).to.be.true;
 		});
 
 		it("should hold the entry corresponding to its own public key", () => {
-			c = new Chord();
+			c = new Chord(config);
 
 			return expect(
 				c.lookupItem(c.id.idString)
@@ -31,11 +37,11 @@ describe("Chord", () => {
 		});
 
 		it("should be able to update any keys it has placed within the network.", () => {
-			var c = new Chord();
+			c = new Chord(config);
 
 			return expect(
 				new Promise((resolve, reject) => {
-					setTimeout(()=> {
+					tim = setTimeout(()=> {
 						c.updateItem(c.id.idString, "Hi there!")
 						.then(
 							result => {return c.lookupItem(c.id.idString)}
@@ -50,11 +56,11 @@ describe("Chord", () => {
 		});
 
 		it("should be able to update an owned key more than once", () => {
-			c = new Chord();
+			c = new Chord(config);
 
 			return expect(
 				new Promise((resolve, reject) => {
-					setTimeout(()=> {
+					tim = setTimeout(()=> {
 						c.updateItem(c.id.idString, "Hi there!")
 						.then(
 							result => {return c.updateItem(c.id.idString, "Hi again!")}
@@ -69,6 +75,22 @@ describe("Chord", () => {
 					}, 500)
 				})
 			).to.eventually.equal("Hi again!");
+		});
+
+		it("should hold onto an object for longer than its max lifetime", () => {
+			c = new Chord(config);
+
+			return expect(
+				new Promise((resolve, reject) => {
+					tim = setTimeout(()=> {
+						return c.lookupItem(c.id.idString)
+						.then(
+							result => resolve(result),
+							reason => reject(reason)
+						)
+					}, 5000)
+				})
+			).to.eventually.equal(c.pubKeyPem);
 		});
 
 		afterEach(() => {


### PR DESCRIPTION
> Huge update. All items stored on CFS now have a concept of access rights -
> a public sequence number and prior hash value combined with a private
> randomised aes key. To update a file, a message is sent containing the key
> and new value, along with encrypted(hash, sequence). While this can be
> used to allow multiple clients to share write access to an item, this is
> not recommended as they will constantly fail to have their updates
> recognised due to the sequence number and hash - these are necessary steps
> to mitigate the liklihood of replay attacks.
> 
> Additionally, this implements message lifetimes and keepalive messages, so
> that dead nodes' data will be lost (so long as no other node on the
> network is actively keeping it alive...). By design, these lifetimes are
> short, and so require constant pinging.

Extra tests implemented, cleanup throughout the system, etc. since the quoted message. Still lacks key relocation - coming up next!
