### PR TITLE
Finishing Chord Spec: Key Relocation, extra disconnection handling.

### DIFF
--- a/src/Chord.js
+++ b/src/Chord.js
@@ -286,7 +286,7 @@ class ConductorChord {
 						//set predecessor and successor to null
 						this._lastPredec = t.node.predecessor;
 
-						if(this._lastPredec !== null)
+						if(this._lastPredec !== null && this._lastPredec !== t.node)
 							this.transition("external_known")
 
 						t.node.predecessor = t.node;

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -573,7 +573,7 @@ class ConductorChord {
 					}
 				}
 			)
-	},
+	}
 
 	_finalResortReconnect () {
 		let nodeIdList = Object.getOwnPropertyNames(this.directNodes);

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -291,8 +291,9 @@ class ConductorChord {
 
 						t.node.predecessor = t.node;
 						t.node.setFinger(0, t.node);
-
-						t._finalResortReconnect();
+						
+						if(this.priorState !== "disconnected" && !t.config.isServer)
+							t._finalResortReconnect();
 					},
 
 					set_successor(node) {
@@ -581,14 +582,11 @@ class ConductorChord {
 		if(nodeIdList.length < 1)
 			return;
 
-		return this.node.stableJoin(this.directNodes[nodeIdList[0]])
+		let chosen = this.directNodes[nodeIdList[0]]
+
+		return this.node.stableJoin(chosen)
 			.then(
 				() => {return this.node.stabilize();}
-			)
-			.then(
-				() => {
-					return srvNode.unlinkClient();
-				}
 			)
 	}
 }

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -522,14 +522,20 @@ class ConductorChord {
 	}
 
 	_checkForID () {
-		if (this.chord.state.substr(0,5)!=="full_")
+		if (this.state.substr(0,5)!=="full_")
 			return;
-		
+
+		u.log(this, "[CHORD]: Checking to see if own public key is still accessible...");
+
 		this.lookupItem(this.id.idString)
 			.then(
 				result => {
-					if (result!==this.pubKeyPem)
+					if (result!==this.pubKeyPem) {
+						u.log(this, "[CHORD]: Public key could not be found - readding...");
 						this.addItem(this.id.idString, this.pubKeyPem);
+					} else {
+						u.log(this, "[CHORD]: Public key still accessible.");
+					}
 				}
 			)
 	}

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -46,6 +46,12 @@ class ConductorChord {
 				channel: null
 			},
 
+			stabilizeInterval: 1000,
+
+			fixFingersInterval: 666,
+
+			moveKeysInterval: 10000,
+
 			isServer: false,
 
 			allowUpgrade: true,
@@ -122,8 +128,9 @@ class ConductorChord {
 		if(this.config.isServer){
 			u.log(this, "Initialising server backing channel.");
 			this.conductor.register(new BootstrapChannelServer(this));
-			setInterval(this.node.stabilize.bind(this.node), 1000);
-			setInterval(this.node.fixFingers.bind(this.node), 666);
+			setInterval(this.node.stabilize.bind(this.node), this.config.stabilizeInterval);
+			setInterval(this.node.fixFingers.bind(this.node), this.config.fixFingersInterval);
+			setInterval(this.fileStore.relocateKeys.bind(this.fileStore), this.config.moveKeysInterval);
 		}
 
 		//space to store, well, external nodes - if you're a server, for instance.
@@ -315,6 +322,12 @@ class ConductorChord {
 					_onEnter() {
 						//Check for current status of successor list, if required.
 						//TODO
+
+						t.fileStore.relocateKeys();
+					},
+
+					set_predecessor (node) {
+						t.fileStore.relocateKeys();
 					},
 
 					disconnect_successor() {
@@ -335,6 +348,10 @@ class ConductorChord {
 					//Deal with it once 
 					disconnect_predecessor() {
 						this.transition("partial");
+					},
+
+					set_predecessor (node) {
+						t.fileStore.relocateKeys();
 					},
 
 					disconnect_all() {
@@ -447,8 +464,9 @@ class ConductorChord {
 						.then(
 							() => {
 								this.server.connect = false;
-								setInterval(this.node.stabilize.bind(this.node), 1000);
-								setInterval(this.node.fixFingers.bind(this.node), 666);
+								setInterval(this.node.stabilize.bind(this.node), this.config.stabilizeInterval);
+								setInterval(this.node.fixFingers.bind(this.node), this.config.fixFingersInterval);
+								setInterval(this.fileStore.relocateKeys.bind(this.fileStore), this.config.moveKeysInterval);
 							}
 						)
 				},

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -44,7 +44,7 @@ class ConductorChord {
 
 			conductorConfig: {
 				channel: null,
-				timeout: 5000
+				timeout: 0
 			},
 
 			stabilizeInterval: 1000,
@@ -221,7 +221,6 @@ class ConductorChord {
 						this.statemachine.disconnect(node);
 					};
 
-					this.knownNodes[conn.id] = node;
 					this.directNodes[conn.id] = node;
 
 					if(ID.compare(conn.id, node.id) !== 0){

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -195,6 +195,11 @@ class ConductorChord {
 					}
 					node.connection = conn;
 
+					if (!node.isConnected()) {
+						node.connection.close();
+						reject("Connection was closed - attempt to obtain link failed.");
+					}
+
 					conn.on("message", msg => {
 						let msgObj = this.messageCore.parseMessage(msg.data);
 						if(msgObj)
@@ -215,8 +220,7 @@ class ConductorChord {
 					this.statemachine.node_connection(node);
 
 					resolve(node);
-				} )
-				.catch( reason => reject(reason) );
+				} );
 		} );
 	}
 

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -184,6 +184,8 @@ class ConductorChord {
 			return this.node;
 		} else if (this.directNodes[saneID]) {
 			return this.directNodes[saneID];
+		} else if (this.knownNodes[saneID]) {
+			return this.knownNodes[saneID];
 		} else {
 			let node = new RemoteNode(this, new ID(saneID), null);
 			this.knownNodes[saneID] = node;
@@ -197,13 +199,11 @@ class ConductorChord {
 		return new Promise( (resolve, reject) => {
 			this.conductor.connectTo(saneId, "Conductor-Chord")
 				.then( conn => {
-					let node;
+					let node = this.obtainRemoteNode(conn.id);
 
-					if (optNode) {
-						node = optNode;
-					} else {
-						node = this.obtainRemoteNode(conn.id);
-					}
+					if (optNode)
+						optNode.connection = conn;
+		
 					node.connection = conn;
 
 					if (!node.isConnected()) {
@@ -221,6 +221,7 @@ class ConductorChord {
 						this.statemachine.disconnect(node);
 					};
 
+					this.knownNodes[conn.id] = node;
 					this.directNodes[conn.id] = node;
 
 					if(ID.compare(conn.id, node.id) !== 0){

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -43,7 +43,8 @@ class ConductorChord {
 			},
 
 			conductorConfig: {
-				channel: null
+				channel: null,
+				timeout: 5000
 			},
 
 			stabilizeInterval: 1000,

--- a/src/Chord.js
+++ b/src/Chord.js
@@ -52,6 +52,8 @@ class ConductorChord {
 
 			moveKeysInterval: 10000,
 
+			checkPubKeyInterval: 2500,
+
 			isServer: false,
 
 			allowUpgrade: true,
@@ -131,6 +133,7 @@ class ConductorChord {
 			setInterval(this.node.stabilize.bind(this.node), this.config.stabilizeInterval);
 			setInterval(this.node.fixFingers.bind(this.node), this.config.fixFingersInterval);
 			setInterval(this.fileStore.relocateKeys.bind(this.fileStore), this.config.moveKeysInterval);
+			setInterval(this._checkForID.bind(this), this.config.checkPubKeyInterval);
 		}
 
 		//space to store, well, external nodes - if you're a server, for instance.
@@ -467,6 +470,7 @@ class ConductorChord {
 								setInterval(this.node.stabilize.bind(this.node), this.config.stabilizeInterval);
 								setInterval(this.node.fixFingers.bind(this.node), this.config.fixFingersInterval);
 								setInterval(this.fileStore.relocateKeys.bind(this.fileStore), this.config.moveKeysInterval);
+								setInterval(this._checkForID.bind(this), this.config.checkPubKeyInterval);
 							}
 						)
 				},
@@ -515,6 +519,19 @@ class ConductorChord {
 
 		if(m)
 			this.message(m);
+	}
+
+	_checkForID () {
+		if (this.chord.state.substr(0,5)!=="full_")
+			return;
+		
+		this.lookupItem(this.id.idString)
+			.then(
+				result => {
+					if (result!==this.pubKeyPem)
+						this.addItem(this.id.idString, this.pubKeyPem);
+				}
+			)
 	}
 }
 

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -66,7 +66,7 @@ class FileStore extends RemoteCallable {
 					);
 				break;
 			case "pubReq":
-				this.answer(message, {i:ID.coerceString(this.chord.id), k:this.pubKeyPem});
+				this.answer(message, {i:ID.coerceString(this.chord.id), k:this.chord.pubKeyPem});
 				break;
 			case "moveKey":
 				this.answer(message, this._moveKey(params));

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -69,7 +69,7 @@ class FileStore extends RemoteCallable {
 				this.answer(message, {i:ID.coerceString(this.chord.id), k:this.chord.pubKeyPem});
 				break;
 			case "moveKey":
-				this.answer(message, this._moveKey(params));
+				this.answer(message, this._moveKey(message.data.params));
 			default:
 				break;
 		}

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -330,23 +330,27 @@ class FileStore extends RemoteCallable {
 				continue;
 
 			//Apparently not - let's get to work!
-			this.call(hash, "pubReq", [])
-				.then(
-					result => {
-						let retID = result.i,
-							cryptor = pki.publicKeyFromPem(result.k),
-							internalObj = this.storage[hash],
-							securedKey;
+			(hash =>
+				{
+				this.call(hash, "pubReq", [])
+					.then(
+						result => {
+							let retID = result.i,
+								cryptor = pki.publicKeyFromPem(result.k),
+								internalObj = this.storage[hash],
+								securedKey;
 
-						if (internalObj) {
-							securedKey = cryptor.encrypt(internalObj.aesKey, "RSA-OAEP");
-							return this.call(retID, "moveKey", [internalObj.key, internalObj.data, internalObj.wasStr, internalObj.seq, internalObj.lHash, securedKey])
-								.then(
-									result => {if (result) delete this.storage[hash];}
-								);
+							if (internalObj) {
+								securedKey = cryptor.encrypt(internalObj.aesKey, "RSA-OAEP");
+								return this.call(retID, "moveKey", [internalObj.key, internalObj.data, internalObj.wasStr, internalObj.seq, internalObj.lHash, securedKey])
+									.then(
+										result => {if (result) delete this.storage[hash];}
+									);
+							}
 						}
-					}
-				);
+					);
+				}
+			)(hash)
 		}
 	}
 

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -360,7 +360,7 @@ class FileStore extends RemoteCallable {
 
 		//Decrypt the secret, just for us.
 		//This ensures current owners can still update their stuff.
-		let secret = this.chord.key.privateKey.decrypt(result.encKey, "RSA-OAEP");
+		let secret = this.chord.key.privateKey.decrypt(secureKey, "RSA-OAEP");
 
 		//Now take the hash of the item's key...
 		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -320,6 +320,9 @@ class FileStore extends RemoteCallable {
 	}
 
 	relocateKeys () {
+		if (this.chord.state.substr(0,5)!=="full_")
+			return;
+
 		for (var hash in this.storage) {
 			//Safety check, and do we own this item?
 			if(!this.storage.hasOwnProperty(hash)

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -334,7 +334,7 @@ class FileStore extends RemoteCallable {
 				.then(
 					result => {
 						let retID = result.i,
-							cryptor = cryptor = pki.publicKeyFromPem(result.k),
+							cryptor = pki.publicKeyFromPem(result.k),
 							internalObj = this.storage[hash],
 							securedKey;
 

--- a/src/FileStore.js
+++ b/src/FileStore.js
@@ -363,7 +363,7 @@ class FileStore extends RemoteCallable {
 		let secret = this.chord.key.privateKey.decrypt(secureKey, "RSA-OAEP");
 
 		//Now take the hash of the item's key...
-		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(key),
+		let hash = sha3["sha3_"+this.chord.config.idWidth].buffer(itemKey),
 			hashStr = ID.coerceString(new ID(hash)),
 			presentObj = this.storage[hashStr];
 

--- a/src/ID.js
+++ b/src/ID.js
@@ -218,6 +218,8 @@ class ID {
 	static coerceString(unknownIDType){
 		if (typeof unknownIDType === "string") {
 			return unknownIDType
+		} else if (unknownIDType instanceof ArrayBuffer || unknownIDType instanceof Array || ArrayBuffer.isView(unknownIDType)) {
+			return new ID(unknownIDType).idString;
 		} else {
 			return unknownIDType.idString;
 		}

--- a/src/Node.js
+++ b/src/Node.js
@@ -265,7 +265,7 @@ class Node{
 
 		u.log(this.chord, `!!! STATE: ${this.chord.state} !!!`)
 
-		if(this.chord.state === "external" && ID.compare(msg.dest, this.id)!== 0) {
+		if(this.chord.state.substr(0,8) === "external" && ID.compare(msg.dest, this.id)!== 0) {
 			let nodeIdList = Object.getOwnPropertyNames(this.chord.directNodes),
 				chosen;
 


### PR DESCRIPTION
Key relocation working as required in the original chord spec - occurs both as an event driven action and as a relatively slow periodic task.

Additionally, made most of the periodic task intervals customisable from within the config object! While Conductor now supports connection timeouts, I haven't yet found a sensible bound that guarantees that the connections should form. In fact, all of the default values will likely be tweaked over the coming weeks.

Extra fixes have been added for disconnection handling - an extra state has been added for the likely case that an external node is still something's successor, and can be brought back into the network. Failing this, the node will try a full reconnect on its own terms after a reasonable time window. As a result, the standard external state will go straight into a full reconnection attempt.#

There are also likely other minuscule fixes.
